### PR TITLE
mocking the Trollop::die module function

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,1 @@
+rvm 1.9.3-p194@ardfeedback --create

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    json (1.7.4)
+    serialport (1.1.0)
+    trollop (2.0)
+    xml-simple (1.1.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  json
+  serialport
+  trollop
+  xml-simple

--- a/lib/ard_feedback_args.rb
+++ b/lib/ard_feedback_args.rb
@@ -2,15 +2,14 @@ require "trollop"
 
 class ArdFeedbackArgs
     def self.parse_args
-        opts = Trollop::options do 
-        	opt :url, "Url to /xml/api for jenkins or builds.json for travis", :type => String, :short => "-u"
-            opt :jenkins, "Use jenkins parser", :short => "-j"
-            opt :travis, "travis api url", :short => "-t"
-            opt :serial, "Serial port use to communicate with arduino", :short => "-s", :default => "/dev/ttyACM0"
-            opt :refresh, "Delay between requests to jenkins (in seconds)", :short => "-r", :type => Integer, :default => 30
-        end
-		Trollop::die :jenkins, "cannot be define with travis" if (opts[:jenkins] && opts[:travis])
-
-		opts
+      opts = Trollop::options do
+        opt :url, "Url to /xml/api for jenkins or builds.json for travis", :type => String, :short => "-u"
+        opt :jenkins, "Use jenkins parser", :short => "-j"
+        opt :travis, "travis api url", :short => "-t"
+        opt :serial, "Serial port use to communicate with arduino", :short => "-s", :default => "/dev/ttyACM0"
+        opt :refresh, "Delay between requests to jenkins (in seconds)", :short => "-r", :type => Integer, :default => 30
+        conflicts :jenkins, :travis
+      end
+      opts
     end
 end

--- a/test/ard_feedback_args_test.rb
+++ b/test/ard_feedback_args_test.rb
@@ -65,7 +65,7 @@ class ArdFeedbackArgsTest < Test::Unit::TestCase
     def test_should_accept_serial_arg
         ARGV[0] = "--serial"
         ARGV[1] = "/dev/serial"
-        
+
         args = ArdFeedbackArgs.parse_args
         assert_equal("/dev/serial", args[:serial])
     end
@@ -73,7 +73,7 @@ class ArdFeedbackArgsTest < Test::Unit::TestCase
     def test_should_accept_short_serial_arg
         ARGV[0] = "-s"
         ARGV[1] = "/dev/serial"
-        
+
         args = ArdFeedbackArgs.parse_args
         assert_equal("/dev/serial", args[:serial])
     end
@@ -81,9 +81,9 @@ class ArdFeedbackArgsTest < Test::Unit::TestCase
     def test_should_not_accept_travis_and_jenkins
         ARGV[0] = "-t"
         ARGV[1] = "-j"
-
-        # well... I don't know how to test that : In that case, Trollop is suppose to die and kill my process. And by consequence kill the process of test... That's not fun
-        #args = ArdFeedbackArgs.parse_args
+        assert_raise DieError do
+          args = ArdFeedbackArgs.parse_args
+        end
     end
 
     def test_should_have_default_serial_arg
@@ -94,7 +94,7 @@ class ArdFeedbackArgsTest < Test::Unit::TestCase
     def test_should_accept_refresh_arg
         ARGV[0] = "--refresh"
         ARGV[1] = "60"
-        
+
         args = ArdFeedbackArgs.parse_args
         assert_equal(60, args[:refresh])
     end
@@ -102,7 +102,7 @@ class ArdFeedbackArgsTest < Test::Unit::TestCase
     def test_should_accept_short_refresh_arg
         ARGV[0] = "-r"
         ARGV[1] = "60"
-        
+
         args = ArdFeedbackArgs.parse_args
         assert_equal(60, args[:refresh])
     end
@@ -111,4 +111,14 @@ class ArdFeedbackArgsTest < Test::Unit::TestCase
         args = ArdFeedbackArgs.parse_args
         assert_equal(30, args[:refresh])
     end
+end
+
+# Monkeypatch to mock the die behaviour (that would kill both script and test otherwise)
+class DieError < StandardError ; end
+
+module Trollop
+  def die arg, msg=nil
+    raise DieError
+  end
+module_function :options, :die
 end

--- a/test/ard_feedback_args_test.rb
+++ b/test/ard_feedback_args_test.rb
@@ -1,6 +1,13 @@
 require "test/unit"
 require_relative "../lib/ard_feedback_args.rb"
 
+module Trollop
+  def with_standard_exception_handling parser
+    yield
+  end
+  module_function :with_standard_exception_handling
+end
+
 class ArdFeedbackArgsTest < Test::Unit::TestCase
     def setup
         #as ARGV is system variable, we flush its content to prevent collision between test
@@ -81,7 +88,7 @@ class ArdFeedbackArgsTest < Test::Unit::TestCase
     def test_should_not_accept_travis_and_jenkins
         ARGV[0] = "-t"
         ARGV[1] = "-j"
-        assert_raise DieError do
+        assert_raise Trollop::CommandlineError do
           args = ArdFeedbackArgs.parse_args
         end
     end
@@ -111,14 +118,4 @@ class ArdFeedbackArgsTest < Test::Unit::TestCase
         args = ArdFeedbackArgs.parse_args
         assert_equal(30, args[:refresh])
     end
-end
-
-# Monkeypatch to mock the die behaviour (that would kill both script and test otherwise)
-class DieError < StandardError ; end
-
-module Trollop
-  def die arg, msg=nil
-    raise DieError
-  end
-module_function :options, :die
 end


### PR DESCRIPTION
Here is a proposal for mocking Trollop::die !

BUT !!
see : https://github.com/tokland/trollop/blob/master/lib/trollop.rb#L252

You could specify conflicts between jenkins and travis using this, so:

``` ruby
      opts = Trollop::options do 
        opt :url, "Url to /xml/api for jenkins or builds.json for travis", :type => String, :short => "-u"
        opt :jenkins, "Use jenkins parser", :short => "-j"
        opt :travis, "travis api url", :short => "-t"
        opt :serial, "Serial port use to communicate with arduino", :short => "-s", :default => "/dev/ttyACM0"
        opt :refresh, "Delay between requests to jenkins (in seconds)", :short => "-r", :type => Integer, :default => 30
        conflicts :jenkins, :travis
      end
```

More tough to test, but is it worth testing it ? Isn't it tested as a Trollop feature in trollop own tests ?
